### PR TITLE
Vanilla parity fix on Folia

### DIFF
--- a/src/main/java/xyz/hynse/foliaflow/util/SchedulerUtil.java
+++ b/src/main/java/xyz/hynse/foliaflow/util/SchedulerUtil.java
@@ -16,7 +16,7 @@ public class SchedulerUtil {
         return false;
     }
 
-    private static Boolean isFolia() {
+    public static Boolean isFolia() {
         if (IS_FOLIA == null) IS_FOLIA = tryFolia();
         return IS_FOLIA;
     }

--- a/src/main/java/xyz/hynse/foliaflow/watcher/PortalWatcher.java
+++ b/src/main/java/xyz/hynse/foliaflow/watcher/PortalWatcher.java
@@ -25,7 +25,7 @@ public class PortalWatcher implements Listener {
         Vector vel = entity.getVelocity();
         Block movingTo = getBlockMovingTo(loc, vel);
 
-        if(movingTo != null && movingTo.getType() == Material.END_PORTAL){
+        if(movingTo.getType() == Material.END_PORTAL){
             Location spawnLoc = movingTo.getLocation();
             spawnLoc.add(0.5, 0.5, 0.5);
 
@@ -37,8 +37,11 @@ public class PortalWatcher implements Listener {
             dummy.setVelocity(dummyVel);
 
             // Add vector seems vanilla.
-            SchedulerUtil.runLaterEntity(dummy, FoliaFlow.instance,
-                () -> dummy.setVelocity(dummyVel.add(new Vector(0, 0.45, 0))),
+            SchedulerUtil.runLaterEntity(dummy, FoliaFlow.instance, () -> {
+                    // Portal teleportation on Folia is a bit below vanilla, so we teleport it above
+                    if (SchedulerUtil.isFolia()) dummy.teleportAsync(dummy.getLocation().add(0, 0.5, 0));
+                    dummy.setVelocity(dummyVel.add(new Vector(0, 0.2, 0)));
+                },
                 2
             );
         }


### PR DESCRIPTION
This uses more vanilla values.
On Folia, blocks are teleported a bit below the right location, se we teleport them above (only on folia)