### PR TITLE
Add configurable coefficients and reload command

### DIFF
--- a/src/main/java/xyz/hynse/foliaflow/FoliaFlow.java
+++ b/src/main/java/xyz/hynse/foliaflow/FoliaFlow.java
@@ -1,15 +1,32 @@
 package xyz.hynse.foliaflow;
 
 import org.bukkit.plugin.java.JavaPlugin;
+
+import xyz.hynse.foliaflow.command.ReloadCommand;
 import xyz.hynse.foliaflow.watcher.PortalWatcher;
 
 public class FoliaFlow extends JavaPlugin {
 
     public static FoliaFlow instance;
+    public static double horizontalCoefficient;
+    public static double verticalCoefficient;
 
     @Override
     public void onEnable() {
         instance = this;
+        register();
+        reload();
+    }
+
+    public void reload() {
+        saveDefaultConfig();
+        reloadConfig();
+        horizontalCoefficient = getConfig().getDouble("horizontal_coefficient");
+        verticalCoefficient = getConfig().getDouble("vertical_coefficient");
+    }
+
+    private void register() {
+        getCommand("flowreload").setExecutor(new ReloadCommand());
         getServer().getPluginManager().registerEvents(new PortalWatcher(), this);
     }
 }

--- a/src/main/java/xyz/hynse/foliaflow/command/ReloadCommand.java
+++ b/src/main/java/xyz/hynse/foliaflow/command/ReloadCommand.java
@@ -1,0 +1,23 @@
+package xyz.hynse.foliaflow.command;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+import xyz.hynse.foliaflow.FoliaFlow;
+
+public class ReloadCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("foliaflow.reload")) return true;
+        try {
+            FoliaFlow.instance.reload();
+            sender.sendMessage(ChatColor.YELLOW + "FoliaFlow reloaded.");
+        } catch (Exception e) {
+            sender.sendMessage(ChatColor.RED + "Something went wrong reloading FoliaFlow, see the console for more.");
+            e.printStackTrace();
+        }
+        return true;
+    }
+}

--- a/src/main/java/xyz/hynse/foliaflow/util/SchedulerUtil.java
+++ b/src/main/java/xyz/hynse/foliaflow/util/SchedulerUtil.java
@@ -16,7 +16,7 @@ public class SchedulerUtil {
         return false;
     }
 
-    private static Boolean isFolia() {
+    public static Boolean isFolia() {
         if (IS_FOLIA == null) IS_FOLIA = tryFolia();
         return IS_FOLIA;
     }

--- a/src/main/java/xyz/hynse/foliaflow/watcher/PortalWatcher.java
+++ b/src/main/java/xyz/hynse/foliaflow/watcher/PortalWatcher.java
@@ -17,6 +17,7 @@ import xyz.hynse.foliaflow.util.SchedulerUtil;
 import static xyz.hynse.foliaflow.util.VelocityUtil.getBlockMovingTo;
 
 public class PortalWatcher implements Listener {
+
     @EventHandler
     public void onFallingBlockToBlock(EntityChangeBlockEvent e){
         if(e.getEntityType() != EntityType.FALLING_BLOCK) return;
@@ -31,8 +32,8 @@ public class PortalWatcher implements Listener {
 
             FallingBlock dummy = loc.getWorld().spawnFallingBlock(spawnLoc, ((FallingBlock) entity).getBlockData());
             Vector dummyVel = vel.clone();
-            dummyVel.setY(-dummyVel.getY());
-            dummyVel.multiply(1.3); // This seems vanilla.
+            dummyVel.multiply(FoliaFlow.horizontalCoefficient);
+            dummyVel.setY(vel.getY() * FoliaFlow.verticalCoefficient);
             dummy.setVelocity(dummyVel);
 
             // Add vector seems vanilla.

--- a/src/main/java/xyz/hynse/foliaflow/watcher/PortalWatcher.java
+++ b/src/main/java/xyz/hynse/foliaflow/watcher/PortalWatcher.java
@@ -25,7 +25,7 @@ public class PortalWatcher implements Listener {
         Vector vel = entity.getVelocity();
         Block movingTo = getBlockMovingTo(loc, vel);
 
-        if(movingTo != null && movingTo.getType() == Material.END_PORTAL){
+        if(movingTo.getType() == Material.END_PORTAL){
             Location spawnLoc = movingTo.getLocation();
             spawnLoc.add(0.5, 0.5, 0.5);
 
@@ -33,12 +33,14 @@ public class PortalWatcher implements Listener {
             Vector dummyVel = vel.clone();
             dummyVel.setY(-dummyVel.getY());
             dummyVel.multiply(1.3); // This seems vanilla.
-            dummyVel.add(new Vector(0, -0.2, 0));
             dummy.setVelocity(dummyVel);
 
             // Add vector seems vanilla.
-            SchedulerUtil.runLaterEntity(dummy, FoliaFlow.instance,
-                () -> dummy.setVelocity(dummyVel.add(new Vector(0, 0.45, 0))),
+            SchedulerUtil.runLaterEntity(dummy, FoliaFlow.instance, () -> {
+                    // Portal teleportation on Folia is a bit below vanilla, so we teleport it above
+                    if (SchedulerUtil.isFolia()) dummy.teleportAsync(dummy.getLocation().add(0, 0.5, 0));
+                    dummy.setVelocity(dummyVel);
+                },
                 2
             );
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,7 @@
+# Don't touch this file unless you know what you're doing
+# Default values seems vanilla.
+# If you find values that seems more vanilla please create a PR
+# https://github.com/Hynse/FoliaFlow
+
+vertical_coefficient: -1.7
+horizontal_coefficient: 1.46

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -1,5 +1,0 @@
-name: FoliaFlow
-version: '${version}'
-main: xyz.hynse.foliaflow.FoliaFlow
-api-version: 1.19
-folia-supported: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,3 +3,8 @@ version: '${version}'
 main: xyz.hynse.foliaflow.FoliaFlow
 api-version: 1.19
 folia-supported: true
+commands:
+  flowreload:
+    description: Reload FoliaFlow
+    usage: /<command>
+    permission: foliaflow.reload


### PR DESCRIPTION
Default config:

```yaml
# Don't touch this file unless you know what you're doing
# Default values seems vanilla.
# If you find values that seems more vanilla please create a PR
# https://github.com/Hynse/FoliaFlow

vertical_coefficient: -1.7
horizontal_coefficient: 1.46
```

This config can be reloaded with `/flowreload` command.
Theses values control velocity coefficients:

```java
            dummyVel.multiply(FoliaFlow.horizontalCoefficient);
            dummyVel.setY(vel.getY() * FoliaFlow.verticalCoefficient);
            dummy.setVelocity(dummyVel);

            // Add vector seems vanilla.
            SchedulerUtil.runLaterEntity(dummy, FoliaFlow.instance, () -> {
                    // Portal teleportation on Folia is a bit below vanilla, so we teleport it above
                    if (SchedulerUtil.isFolia()) dummy.teleportAsync(dummy.getLocation().add(0, 0.5, 0));
                    dummy.setVelocity(dummyVel);
                },
                2
            );
```